### PR TITLE
Enhance issue tagging and DTO mapping with tags 

### DIFF
--- a/src/main/java/com/dev/issuebook/dto/IssueDTO.java
+++ b/src/main/java/com/dev/issuebook/dto/IssueDTO.java
@@ -10,23 +10,27 @@ public class IssueDTO {
 	private String issueDesc;
 	private String issueType; // e.g., "API", "UI", "Database"
 	private Boolean resolved;
+	private String rootCause;
 	private String resolution; // optional: explanation of fix
 	private LocalDateTime createdAt;
-	private List<String> tags; // list of tag names
+	private String tagsStr;
+	private List<TagDTO> tags; // list of tag names
 
 	// Constructors
 	public IssueDTO() {
 	}
 
-	public IssueDTO(Long id, Long userId, String issueDesc, String issueType, Boolean resolved, String resolution,
-			LocalDateTime createdAt, LocalDateTime updatedAt, List<String> tags) {
+	public IssueDTO(Long id, Long userId, String issueDesc, String issueType, Boolean resolved, String rootCause, String resolution,
+			LocalDateTime createdAt, LocalDateTime updatedAt, String tagsStr, List<TagDTO> tags) {
 		this.id = id;
 		this.userId = userId;
 		this.issueDesc = issueDesc;
 		this.issueType = issueType;
 		this.resolved = resolved;
+		this.rootCause = rootCause;
 		this.resolution = resolution;
 		this.createdAt = createdAt;
+		this.tagsStr = tagsStr;
 		this.tags = tags;
 	}
 
@@ -71,6 +75,14 @@ public class IssueDTO {
 		this.resolved = resolved;
 	}
 
+	public String getRootCause() {
+		return rootCause;
+	}
+
+	public void setRootCause(String rootCause) {
+		this.rootCause = rootCause;
+	}
+
 	public String getResolution() {
 		return resolution;
 	}
@@ -87,11 +99,19 @@ public class IssueDTO {
 		this.createdAt = createdAt;
 	}
 
-	public List<String> getTags() {
+	public String getTagsStr() {
+		return tagsStr;
+	}
+
+	public void setTagsStr(String tagsStr) {
+		this.tagsStr = tagsStr;
+	}
+
+	public List<TagDTO> getTags() {
 		return tags;
 	}
 
-	public void setTags(List<String> tags) {
+	public void setTags(List<TagDTO> tags) {
 		this.tags = tags;
 	}
 }

--- a/src/main/java/com/dev/issuebook/mapper/IssueMapper.java
+++ b/src/main/java/com/dev/issuebook/mapper/IssueMapper.java
@@ -1,12 +1,16 @@
 package com.dev.issuebook.mapper;
 
 import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.dev.issuebook.dto.IssueDTO;
+import com.dev.issuebook.dto.TagDTO;
 import com.dev.issuebook.entity.IssueEntity;
 
 public class IssueMapper {
-
+	
 	// Entity → DTO
 	public static IssueDTO toDTO(IssueEntity entity) {
 		if (entity == null)
@@ -18,12 +22,20 @@ public class IssueMapper {
 		dto.setIssueDesc(entity.getIssueDesc());
 		dto.setIssueType(entity.getIssueType());
 		dto.setResolved(entity.getResolved());
+		dto.setRootCause(entity.getRootCause());
 		dto.setResolution(entity.getResolution());
 		dto.setCreatedAt(entity.getCreatedAt());
 
 		// Tags are not stored in IssueEntity directly; they come from Tag-Service
 		dto.setTags(Collections.emptyList());
 
+		return dto;
+	}
+	
+	public static IssueDTO toDTOWithTags(IssueEntity entity, Map<Long, List<TagDTO>> issueTagsMap) {
+		IssueDTO dto = IssueMapper.toDTO(entity);
+		dto.setTags(issueTagsMap.get(dto.getId()));
+		
 		return dto;
 	}
 
@@ -38,10 +50,42 @@ public class IssueMapper {
 		entity.setIssueDesc(dto.getIssueDesc());
 		entity.setIssueType(dto.getIssueType());
 		entity.setResolved(dto.getResolved());
+		entity.setRootCause(dto.getRootCause());
 		entity.setResolution(dto.getResolution());
 		entity.setCreatedAt(dto.getCreatedAt());
 
 		// Tags are ignored here since they belong to Tag-Service
 		return entity;
 	}
+
+	// Entity List → DTO List
+	public static List<IssueDTO> toDTOList(List<IssueEntity> entities) {
+		if (entities == null || entities.isEmpty())
+			return Collections.emptyList();
+
+		return entities.stream().map(IssueMapper::toDTO).collect(Collectors.toList());
+	}
+
+	// DTO List → Entity List
+	public static List<IssueEntity> toEntityList(List<IssueDTO> dtos) {
+		if (dtos == null || dtos.isEmpty())
+			return Collections.emptyList();
+
+		return dtos.stream().map(IssueMapper::toEntity).collect(Collectors.toList());
+	}
+
+	public static List<IssueDTO> toDTOListIncludeTags(List<IssueEntity> entities, Map<Long, List<TagDTO>> issueTagsMap) {
+		if (entities == null || entities.isEmpty())
+			return Collections.emptyList();
+
+		return entities.stream().map(IssueMapper::toDTO).map(dto -> IssueMapper.setTags(dto, issueTagsMap))
+				.collect(Collectors.toList());
+	}
+
+	private static IssueDTO setTags(IssueDTO dto, Map<Long, List<TagDTO>> issueTagsMap) {
+		dto.setTags(issueTagsMap.get(dto.getId()));
+		System.out.println(dto.getTags());
+		return dto;
+	}
+
 }

--- a/src/main/java/com/dev/issuebook/msclient/TagsClient.java
+++ b/src/main/java/com/dev/issuebook/msclient/TagsClient.java
@@ -1,17 +1,24 @@
 package com.dev.issuebook.msclient;
 
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
 import com.dev.issuebook.dto.TagAssignmentDTO;
+import com.dev.issuebook.dto.TagDTO;
 
 @FeignClient("TAG-SERVICE")
 public interface TagsClient {
 
 	@PostMapping("/api/tag-assignments")
 	List<TagAssignmentDTO> assignTag(@RequestBody TagAssignmentDTO assignmentDTO);
+	
+	@GetMapping("api/tags/user/{createdBy}")
+	Map<Long, List<TagDTO>> getTagsByCreatedBy(@PathVariable Long createdBy);
 
 }


### PR DESCRIPTION
Refactored IssueController to handle tags as TagDTO objects and fetch tags from Tag-Service when retrieving issues. Updated IssueDTO to include rootCause, tagsStr, and a list of TagDTOs. Extended IssueMapper with methods to map tags and support new DTO structure. Modified TagsClient to support fetching tags by user. #35 