### PR TITLE
Add Resilience4j circuit breaker to NotificationClient

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,12 @@
             <artifactId>lombok</artifactId>
             <scope>provided</scope>
         </dependency>
+		<dependency>
+			<groupId>io.github.resilience4j</groupId>
+			<artifactId>resilience4j-spring-boot2</artifactId>
+			<version>2.3.0</version>
+			<scope>compile</scope>
+		</dependency>
     </dependencies>
 
 	<build>

--- a/src/main/java/com/dev/issuebook/msclient/NotificationClient.java
+++ b/src/main/java/com/dev/issuebook/msclient/NotificationClient.java
@@ -2,18 +2,37 @@ package com.dev.issuebook.msclient;
 
 import java.util.Map;
 
-import com.dev.issuebook.dto.NotificationRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
+import com.dev.issuebook.dto.NotificationRequest;
+
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+
 @FeignClient("notification-service")
 public interface NotificationClient {
+	
+	Logger log = LoggerFactory.getLogger(NotificationClient.class);
 
-    @PostMapping("/notification/send-email")
-    String sendEmail(@RequestBody Map<String, Object> body);
+	@CircuitBreaker(name = "sendEmailCB", fallbackMethod = "sendEmailFallback")
+	@PostMapping("/notification/send-email")
+	String sendEmail(@RequestBody Map<String, Object> body);
 
-    @PostMapping("/notification/action")
-    void notifyAction(@RequestBody NotificationRequest request);
+	@CircuitBreaker(name = "notifyActionCB", fallbackMethod = "notifyActionFallback")
+	@PostMapping("/notification/action")
+	void notifyAction(@RequestBody NotificationRequest request);
+
+	default String sendEmailFallback(Exception ex) {
+		System.out.println("Notifcation Service - send-email failed");
+		return "failure";
+	}
+
+	default void notifyActionFallback(Exception ex) {
+		log.error("Notifcation Service - notify action failed.");
+		log.error(ex.getMessage());
+	}
 
 }

--- a/src/main/java/com/dev/issuebook/service/impl/DevIssueBookFileServiceImpl.java
+++ b/src/main/java/com/dev/issuebook/service/impl/DevIssueBookFileServiceImpl.java
@@ -20,7 +20,6 @@ import org.springframework.stereotype.Service;
 import com.dev.issuebook.constant.Keys;
 import com.dev.issuebook.db.repository.IssueBkpRepository;
 import com.dev.issuebook.service.DevIssueBookFileService;
-import com.dev.issuebook.util.DevIssueBookHelper;
 
 @Service
 public class DevIssueBookFileServiceImpl implements DevIssueBookFileService {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,7 +26,25 @@ eureka:
     register-with-eureka: true
     service-url:
       defaultZone: ${EUREKA_SERVER_ADDRESS:http://localhost:8761/eureka}
-      
+
+resilience4j:
+   circuitbreaker:
+      instances:
+        sampleService:
+          registerHealthIndicator: true
+          slidingWindowSize: 5
+          minimumNumberOfCalls: 5
+          failureRateThreshold: 50
+          waitDurationInOpenState: 5s
+          permittedNumberOfCallsInHalfOpenState: 3
+          eventConsumerBufferSize: 10
+
+management:
+    endpoints:
+      web:
+        exposure:
+          include: '*'
+     
 logging:
   level:
     org:


### PR DESCRIPTION
Integrated Resilience4j circuit breaker with NotificationClient methods to improve fault tolerance and added fallback methods for service failures. Updated pom.xml to include resilience4j-spring-boot2 dependency and configured circuit breaker settings in application.yml.