### PR TITLE
Add endpoint to fetch issues by tag

### DIFF
--- a/src/main/java/com/dev/issuebook/controller/IssueController.java
+++ b/src/main/java/com/dev/issuebook/controller/IssueController.java
@@ -2,6 +2,7 @@ package com.dev.issuebook.controller;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -136,6 +137,17 @@ public class IssueController {
     public ResponseEntity<List<IssueEntity>> getUnresolvedIssues() {
     	
         return ResponseEntity.ok(issueService.getUnresolvedIssues());
+    }
+    
+    @PreAuthorize("hasAuthority('ROLE_USER')")
+    @GetMapping("/tag/{tagId}")
+    public ResponseEntity<List<IssueDTO>> getIssuesByTag(@PathVariable Long tagId) {
+    	
+    	Map<Long, List<TagDTO>> issueTagsMap = tagsClient.getTagsByTagAndCreatedBy(tagId, Long.valueOf(httpServletRequest.getHeader("userid")));
+    	
+    	List<IssueEntity> issues = issueService.findByIdIn(new ArrayList<>(issueTagsMap.keySet().stream().collect(Collectors.toList())));
+    	
+        return ResponseEntity.ok(IssueMapper.toDTOListIncludeTags(issues, issueTagsMap));
     }
 
     @PreAuthorize("hasAuthority('ROLE_USER')")

--- a/src/main/java/com/dev/issuebook/db/repository/IssueRepository.java
+++ b/src/main/java/com/dev/issuebook/db/repository/IssueRepository.java
@@ -24,4 +24,7 @@ public interface IssueRepository extends JpaRepository<IssueEntity, Long> {
 
 	// 🔍 Find issues by keyword in description
 	List<IssueEntity> findByIssueDescContainingIgnoreCase(String keyword);
+	
+	//
+	List<IssueEntity> findByIdIn(List<Long> ids);
 }

--- a/src/main/java/com/dev/issuebook/dto/TagDTO.java
+++ b/src/main/java/com/dev/issuebook/dto/TagDTO.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 
 public class TagDTO {
 
+	private Long id;
 	private String uuid;
 	private String name;
 	private String slug;
@@ -14,13 +15,22 @@ public class TagDTO {
 	public TagDTO() {
 	}
 
-	public TagDTO(String uuid, String name, String slug, String description, String color, LocalDateTime createdAt) {
+	public TagDTO(Long id, String uuid, String name, String slug, String description, String color, LocalDateTime createdAt) {
 		this.uuid = uuid;
 		this.name = name;
 		this.slug = slug;
 		this.description = description;
 		this.color = color;
 		this.createdAt = createdAt;
+		this.id = id;
+	}
+	
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
 	}
 
 	public String getUuid() {

--- a/src/main/java/com/dev/issuebook/msclient/TagsClient.java
+++ b/src/main/java/com/dev/issuebook/msclient/TagsClient.java
@@ -29,6 +29,10 @@ public interface TagsClient {
 	@CircuitBreaker(name = "getTagsByCreatedByCB", fallbackMethod = "getTagsByCreatedByFallback")
 	@GetMapping("api/tags/user/{createdBy}")
 	Map<Long, List<TagDTO>> getTagsByCreatedBy(@PathVariable Long createdBy);
+	
+	@CircuitBreaker(name = "getTagsByTagAndCreatedBy", fallbackMethod = "getTagsByTagAndCreatedByFallback")
+	@GetMapping("api/tags/user/{createdBy}/{tagId}")
+	Map<Long, List<TagDTO>> getTagsByTagAndCreatedBy(@PathVariable Long tagId, @PathVariable Long createdBy);
 
 	@CircuitBreaker(name = "removeAllAssignmentsForEntityCB", fallbackMethod = "removeAllAssignmentsForEntityFallback")
 	@DeleteMapping("api/tag-assignments/{entityType}/{entityId}")
@@ -42,6 +46,12 @@ public interface TagsClient {
 
 	default Map<Long, List<TagDTO>> getTagsByCreatedByFallback(Exception ex) {
 		log.error("Tag Service - Get tags by user failed.");
+		log.error(ex.getMessage());
+		return Map.of();
+	}
+	
+	default Map<Long, List<TagDTO>> getTagsByTagAndCreatedByFallback(Exception ex) {
+		log.error("Tag Service - Get tags by tag and user failed.");
 		log.error(ex.getMessage());
 		return Map.of();
 	}

--- a/src/main/java/com/dev/issuebook/service/IssueService.java
+++ b/src/main/java/com/dev/issuebook/service/IssueService.java
@@ -1,6 +1,7 @@
 package com.dev.issuebook.service;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -71,4 +72,9 @@ public class IssueService {
         }
         issueRepository.deleteById(id);
     }
+
+	public List<IssueEntity> findByIdIn(List<Long> arrayList) {
+		return issueRepository.findByIdIn(arrayList);
+		
+	}
 }


### PR DESCRIPTION
Introduce a new GET /tag/{tagId} endpoint (ROLE_USER) to retrieve issues associated with a specific tag for the requesting user. Implemented client, DTO, repo and service support: TagsClient gains getTagsByTagAndCreatedBy and its fallback; TagDTO now includes an id field and updated constructor; IssueRepository adds findByIdIn; IssueService adds a findByIdIn delegating method; IssueController wires these together and maps issues with their tags via IssueMapper. Minor import adjustments added where needed.